### PR TITLE
Fix error on homepage

### DIFF
--- a/EGO Forum Enhancement.user.js
+++ b/EGO Forum Enhancement.user.js
@@ -559,6 +559,7 @@ function handleApplicationPage() {
     else if (url.match(/^https:\/\/www\.edgegamers\.com\/application\/\d+\/?$/))
         // Application Page
         handleApplicationPage();
-
-    handleGenericThread();
+    
+    if(!url.match(/^https:\/\/www\.edgegamers\.com\/-\/$/))
+        handleGenericThread();
 })();


### PR DESCRIPTION
Currently, breadcrumbs are attempted to be accessed on the main home page, leading to an error