### PR TITLE
[FORUMS] Add "Approve" and "Unapprove" buttons to thread posts

### DIFF
--- a/src/EGO Forum Enhancement.ts
+++ b/src/EGO Forum Enhancement.ts
@@ -884,8 +884,8 @@ function addTrashButton(before: HTMLDivElement) {
  * Adds additional buttons to post action bars to make it easier to perform some actions.
  */
 function addPostActionBarButtons() {
-    const threadId = window.location.href.match(/threads\/(?<post_id>\d+)/);
-    if (!threadId) return;
+    const threadId = getThreadId();
+    if (!threadId || threadId.length == 0) return;
 
     const posts = document.querySelectorAll(
         ".message.message--post"
@@ -1268,6 +1268,16 @@ function getForumId() {
     return document
         .getElementById("XF")!
         .dataset.containerKey?.replace("node-", "");
+}
+
+/**
+ * Gets the ID of the current thread
+ * @returns {string} Thread ID
+ */
+function getThreadId() {
+    return document
+        .getElementById("XF")!
+        .dataset.contentKey?.replace("thread-", "");
 }
 
 /**

--- a/src/EGO Forum Enhancement.ts
+++ b/src/EGO Forum Enhancement.ts
@@ -3,7 +3,7 @@
 // @namespace    https://github.com/blankdvth/eGOScripts/blob/master/src/EGO%20Forum%20Enhancement.ts
 // @version      4.9.5
 // @description  Add various enhancements & QOL additions to the EdgeGamers Forums that are beneficial for Leadership members.
-// @author       blank_dvth, Skle, MSWS
+// @author       blank_dvth, Skle, MSWS, PixeL
 // @match        https://www.edgegamers.com/*
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=edgegamers.com
 // @require      https://peterolson.github.io/BigInteger.js/BigInteger.min.js

--- a/src/EGO Forum Enhancement.ts
+++ b/src/EGO Forum Enhancement.ts
@@ -954,7 +954,7 @@ function addPostActionBarButtons() {
         }
 
         approvalButton.onclick = () => {
-            handlePostApproval(threadId[1], postId, isUnapproved);
+            setPostApprovalStatus(threadId[1], postId, isUnapproved);
         };
 
         actionBarSet.appendChild(approvalButton);
@@ -964,7 +964,7 @@ function addPostActionBarButtons() {
 /**
  * Handles (un)approving a thread post by ID.
  */
-async function handlePostApproval(
+async function setPostApprovalStatus(
     threadId: string,
     postId: string,
     approve: boolean


### PR DESCRIPTION
Adds on approve/unapprove buttons to the existing action bar on posts in threads.
It just executes the http requests that the actual XF-JS does in the background.

@blankdvth
